### PR TITLE
replace internal used binaryrow with flink-table-common library

### DIFF
--- a/holo-client/pom.xml
+++ b/holo-client/pom.xml
@@ -79,9 +79,9 @@
         </dependency>
 
         <dependency>
-            <groupId>com.alibaba.hologres</groupId>
-            <artifactId>binaryrow</artifactId>
-            <version>0.0.2.3-SNAPSHOT</version>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>1.20.1</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The change is quite straightforward: replacing the internal closed-source snapshot library with the open-sourced flink-table-common.