### PR TITLE
Support v1 write mode for catalog table to enable partial column writes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tools/releasing/release
 tools/japicmp-output
 user-local.properties
 image-building-target/
+.java-version

--- a/hologres-connector-spark-3.x/src/main/scala/com/alibaba/hologres/spark3/HoloTable.scala
+++ b/hologres-connector-spark-3.x/src/main/scala/com/alibaba/hologres/spark3/HoloTable.scala
@@ -46,7 +46,7 @@ class HoloTable(
       HoloTableType.QUERY
     } else {
       optimizeConfigs = SparkHoloUtil.chooseBestMode(sparkSchema, hologresConfigs)
-      if (optimizeConfigs.needReshuffle) {
+      if (optimizeConfigs.needReshuffle || optimizeConfigs.useV1Write) {
         HoloTableType.TABLE_V1
       } else {
         HoloTableType.TABLE_V2
@@ -65,11 +65,11 @@ class HoloTable(
   ).asJava
 
   override def newWriteBuilder(info: LogicalWriteInfo): WriteBuilder = {
-    // 检查plan中的schema是否与sparkSchema一致, plan中的schema只需要检查字段数量和类型
-    SparkHoloUtil.checkSparkTableSchema(optimizeConfigs, sparkSchema, info.schema())
     if (tableType() == HoloTableType.TABLE_V1) {
       new HoloWriterBuilderV1(optimizeConfigs, sparkSchema)
     } else {
+      // 对于Table V2检查plan中的schema是否与sparkSchema一致, plan中的schema只需要检查字段数量和类型
+      SparkHoloUtil.checkSparkTableSchema(optimizeConfigs, sparkSchema, info.schema())
       new HoloWriterBuilder(optimizeConfigs, sparkSchema)
     }
   }

--- a/hologres-connector-spark-3.x/src/main/scala/com/alibaba/hologres/spark3/SourceProvider.scala
+++ b/hologres-connector-spark-3.x/src/main/scala/com/alibaba/hologres/spark3/SourceProvider.scala
@@ -60,7 +60,7 @@ class SourceProvider extends DataSourceRegister
 
   override def createRelation(sqlContext: SQLContext, mode: SaveMode, parameters: Map[String, String], data: DataFrame): BaseRelation = {
     val hologresConfigs = new HologresConfigs(parameters)
-    RepartitionUtil.reShuffleThenWrite(data, hologresConfigs, saveMode = mode)
+    RepartitionUtil.v1Write(data, hologresConfigs, saveMode = mode)
     new HologresRelation(hologresConfigs, data.schema, mode == SaveMode.Overwrite)(sqlContext.sparkSession)
   }
 }

--- a/hologres-connector-spark-3.x/src/main/scala/com/alibaba/hologres/spark3/sink/HoloWriterBuilderV1.scala
+++ b/hologres-connector-spark-3.x/src/main/scala/com/alibaba/hologres/spark3/sink/HoloWriterBuilderV1.scala
@@ -50,7 +50,7 @@ class HologresRelation(hologresConfigs: HologresConfigs,
                        sparkSchema: StructType,
                        is_overwrite: Boolean)(@transient val sparkSession: SparkSession) extends BaseRelation with InsertableRelation {
   override def insert(data: DataFrame, overwrite: Boolean): Unit = {
-    RepartitionUtil.reShuffleThenWrite(data, hologresConfigs, saveMode = if (is_overwrite) SaveMode.Overwrite else SaveMode.Append)
+    RepartitionUtil.v1Write(data, hologresConfigs, saveMode = if (is_overwrite) SaveMode.Overwrite else SaveMode.Append)
   }
 
   override def sqlContext: SQLContext = sparkSession.sqlContext

--- a/hologres-connector-spark-3.x/src/test/scala/com/alibaba/hologres/spark3/SparkHoloTableCatalogSuite.scala
+++ b/hologres-connector-spark-3.x/src/test/scala/com/alibaba/hologres/spark3/SparkHoloTableCatalogSuite.scala
@@ -106,4 +106,48 @@ class SparkHoloTableCatalogSuite extends SparkHoloSuiteBase {
     testUtils.dropTable(table)
   }
 
+
+  test("Holo Table Catalog partial columns write with v1 and v2 Test") {
+    val ddl = "create table TABLE_NAME (pk int primary key, c1 int, c2 int);"
+    val table = "table_for_holo_test_" + randomSuffix
+    testUtils.dropTable(table)
+    testUtils.createTable(ddl, table, hasPk = true)
+
+    // 1. 全列写入
+    spark.conf.set("spark.sql.catalog.hologres_full", "com.alibaba.hologres.spark3.HoloTableCatalog")
+    spark.conf.set("spark.sql.catalog.hologres_full.username", testUtils.username)
+    spark.conf.set("spark.sql.catalog.hologres_full.password", testUtils.password)
+    spark.conf.set("spark.sql.catalog.hologres_full.jdbcurl", testUtils.jdbcUrl)
+    spark.sql(s"insert into hologres_full.public.$table select 1 as pk, 1 as c1, 1 as c2")
+    checkAnswer(spark.sql(s"select * from hologres_full.public.$table"), Seq(Row(1, 1, 1)))
+
+    // 2. V2 部分列写入 -> 报错
+    spark.conf.set("spark.sql.catalog.hologres_v2", "com.alibaba.hologres.spark3.HoloTableCatalog")
+    spark.conf.set("spark.sql.catalog.hologres_v2.username", testUtils.username)
+    spark.conf.set("spark.sql.catalog.hologres_v2.password", testUtils.password)
+    spark.conf.set("spark.sql.catalog.hologres_v2.jdbcurl", testUtils.jdbcUrl)
+    spark.conf.set("spark.sql.catalog.hologres_v2.write.mode", "insert")
+    spark.conf.set("spark.sql.catalog.hologres_v2.write.on_conflict_action", "INSERT_OR_UPDATE")
+    spark.conf.set("spark.sql.catalog.hologres_v2.write.use_v1_write", "false")
+    val ex = intercept[Exception] {
+      spark.sql(s"insert into hologres_v2.public.$table select 1 as pk, 10 as c1")
+    }
+    assert(ex.getMessage.contains("schema length not match"))
+
+    // 2. V1 部分列写入 -> 成功，部分列更新 pk=1 的 c1
+    spark.conf.set("spark.sql.catalog.hologres_v1", "com.alibaba.hologres.spark3.HoloTableCatalog")
+    spark.conf.set("spark.sql.catalog.hologres_v1.username", testUtils.username)
+    spark.conf.set("spark.sql.catalog.hologres_v1.password", testUtils.password)
+    spark.conf.set("spark.sql.catalog.hologres_v1.jdbcurl", testUtils.jdbcUrl)
+    spark.conf.set("spark.sql.catalog.hologres_v1.write.mode", "insert")
+    spark.conf.set("spark.sql.catalog.hologres_v1.write.on_conflict_action", "INSERT_OR_UPDATE")
+    spark.conf.set("spark.sql.catalog.hologres_v1.write.use_v1_write", "true")
+    spark.sql(s"insert into hologres_v1.public.$table select 1 as pk, 10 as c1")
+    checkAnswer(
+      spark.sql(s"select * from hologres_v1.public.$table"),
+      Seq(Row(1, 10, 1))
+    )
+
+    testUtils.dropTable(table)
+  }
 }

--- a/hologres-connector-spark-base/src/main/scala/com/alibaba/hologres/spark/BaseSourceProvider.scala
+++ b/hologres-connector-spark-base/src/main/scala/com/alibaba/hologres/spark/BaseSourceProvider.scala
@@ -28,6 +28,7 @@ class BaseSourceProvider() {
   val WRITE_ENABLE_STRICT_DATATYPE_CHECK = "write.strict_datatype_check"
   val WRITE_ON_CONFLICT_ACTION = "write.on_conflict_action"
   val WRITE_OVERWRITE_DROP_FORCE = "write.overwrite_drop_force"
+  val WRITE_USE_V1_WRITE = "write.use_v1_write"
   // write insert
   val WRITE_INSERT_BATCH_SIZE = "write.insert.batch_size"
   val WRITE_INSERT_BATCH_BYTE_SIZE = "write.insert.batch_byte_size"

--- a/hologres-connector-spark-base/src/main/scala/com/alibaba/hologres/spark/config/HologresConfigs.scala
+++ b/hologres-connector-spark-base/src/main/scala/com/alibaba/hologres/spark/config/HologresConfigs.scala
@@ -101,6 +101,7 @@ class HologresConfigs(sourceOptions: Map[String, String]) extends Serializable {
   val writeStrictDataTypeCheck: Boolean = sourceOptions.getOrElse("write.strict_datatype_check", "false").toBoolean
   val disableRightJoinInCopy: Boolean = sourceOptions.getOrElse("write.copy.disable_right_join", "false").toBoolean
   val overWriteDropForce: Boolean = sourceOptions.getOrElse("write.overwrite_drop_force", "true").toBoolean
+  val useV1Write: Boolean = sourceOptions.getOrElse("write.use_v1_write", "false").toBoolean
 
   // -------------------------------------read----------------------------------------
   private val readModeStr: String = sourceOptions.getOrElse("read.mode", "auto").toLowerCase

--- a/hologres-connector-spark-base/src/main/scala/com/alibaba/hologres/spark/utils/RepartitionUtil.scala
+++ b/hologres-connector-spark-base/src/main/scala/com/alibaba/hologres/spark/utils/RepartitionUtil.scala
@@ -30,15 +30,19 @@ object RepartitionUtil {
 
   private val logger = new LoggerWrapper(getClass)
 
-  def reShuffleThenWrite(inputDf: DataFrame, hologresConfigs: HologresConfigs, saveMode: SaveMode): Unit = {
+  def v1Write(inputDf: DataFrame, hologresConfigs: HologresConfigs, saveMode: SaveMode): Unit = {
     logger.setSparkAppName(hologresConfigs.sparkAppName)
     logger.setSparkAppId(hologresConfigs.sparkAppId)
     logger.setHoloTableName(hologresConfigs.table)
 
-    val reShuffledDf = reShuffleByHoloDistributionKey(inputDf,
-      hologresConfigs.username, hologresConfigs.password, hologresConfigs.jdbcUrl, hologresConfigs.table)
-    // 将shuffle之后的DataFrame写入到Hologres中, 原样传入所有写入和通用参数
-    reShuffledDf.write
+    val dfToWrite = if (hologresConfigs.needReshuffle) {
+      reShuffleByHoloDistributionKey(inputDf,
+        hologresConfigs.username, hologresConfigs.password, hologresConfigs.jdbcUrl, hologresConfigs.table)
+    } else {
+      inputDf
+    }
+
+    val writer = dfToWrite.write
       .format("hologres")
       .option("username", hologresConfigs.username)
       .option("password", hologresConfigs.password)
@@ -62,9 +66,12 @@ object RepartitionUtil {
       .option("write.copy.dirty_data_check", hologresConfigs.writeCopyDirtyDataCheck)
       .option("write.strict_datatype_check", hologresConfigs.writeStrictDataTypeCheck)
       .option("write.remove_u0000", hologresConfigs.writeRemoveU0000)
-      .option("write.reshuffle_by_holo_distribution_key", "true")
-      .mode(saveMode)
-      .save()
+
+    if (hologresConfigs.needReshuffle) {
+      writer.option("write.reshuffle_by_holo_distribution_key", "true")
+    }
+
+    writer.mode(saveMode).save()
   }
 
   @deprecated()
@@ -87,7 +94,7 @@ object RepartitionUtil {
     logger.setSparkAppId(hologresConfigs.sparkAppId)
     logger.setHoloTableName(hologresConfigs.table)
 
-    reShuffleThenWrite(inputDf, hologresConfigs, saveMode)
+    v1Write(inputDf, hologresConfigs, saveMode)
   }
 
   /**


### PR DESCRIPTION
Currently, writing to Hologres tables via Catalog using the V2 write path requires the number of write columns to match the table schema exactly, which does not support partial column writes.

Changes:
1. Add `write.use_v1_write` config option to allow catalog tables to use the V1 write path, enabling partial column writes
2. Rename `reShuffleThenWrite` to `v1Write`, conditionally reshuffle based on `needReshuffle`
3. Keep schema check only for V2 write path, skip it for V1