### PR TITLE
Support full lookup cache for Flink Hologres connector

### DIFF
--- a/hologres-connector-flink-1.19/src/test/java/com/alibaba/hologres/connector/flink/dim/HologresDimTableITTest.java
+++ b/hologres-connector-flink-1.19/src/test/java/com/alibaba/hologres/connector/flink/dim/HologresDimTableITTest.java
@@ -512,6 +512,11 @@ public class HologresDimTableITTest extends HologresTestBase {
         testDimTableWithCache("PARTIAL");
     }
 
+    @Test
+    public void testDimTableWithFullCache() {
+        testDimTableWithCache("FULL");
+    }
+
     private void runTest() {
         runTest("dim");
     }
@@ -679,6 +684,8 @@ public class HologresDimTableITTest extends HologresTestBase {
                         + "'lookup.cache'='"
                         + cacheStrategy
                         + "',\n"
+                        + "'lookup.full-cache.reload-strategy'='periodic',\n"
+                        + "'lookup.full-cache.periodic-reload.interval'='10 min',\n"
                         + "'lookup.partial-cache.expire-after-access'='18213s',\n"
                         + "'lookup.partial-cache.expire-after-write'='10000s',\n"
                         + "'lookup.partial-cache.max-rows'='10000'"

--- a/hologres-connector-flink-base/src/main/java/com/alibaba/hologres/connector/flink/config/HologresConfigs.java
+++ b/hologres-connector-flink-base/src/main/java/com/alibaba/hologres/connector/flink/config/HologresConfigs.java
@@ -68,6 +68,14 @@ public class HologresConfigs {
             key("source.scan.fetch-size".toLowerCase()).intType().defaultValue(256);
     public static final ConfigOption<Integer> SCAN_TIMEOUT_SECONDS =
             key("source.scan.timeout-seconds".toLowerCase()).intType().defaultValue(28800);
+    public static final ConfigOption<Integer> SCAN_SPLIT_COUNT =
+            key("source.scan.split-count".toLowerCase())
+                    .intType()
+                    .defaultValue(-1)
+                    .withDescription(
+                            "The number of input splits for full table scan. "
+                                    + "By default, one split is created for each Hologres shard. "
+                                    + "Set a positive value to merge Hologres shards into fewer input splits.");
     public static final ConfigOption<Boolean> ENABLE_FILTER_PUSH_DOWN =
             key("source.filter-push-down.enabled".toLowerCase()).booleanType().defaultValue(false);
 

--- a/hologres-connector-flink-base/src/main/java/com/alibaba/hologres/connector/flink/source/HologresTableSource.java
+++ b/hologres-connector-flink-base/src/main/java/com/alibaba/hologres/connector/flink/source/HologresTableSource.java
@@ -108,7 +108,9 @@ public class HologresTableSource
     @Override
     public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context) {
         if (config.get(LookupOptions.CACHE_TYPE).equals(LookupOptions.LookupCacheType.FULL)) {
-            return FullCachingLookupProvider.of(createScanRuntimeProvider(), getCacheReloadTrigger());
+            logFullCacheConfig();
+            return FullCachingLookupProvider.of(
+                    createScanRuntimeProvider(), getCacheReloadTrigger());
         }
 
         String[] lookupKeys = new String[context.getKeys().length];
@@ -158,6 +160,26 @@ public class HologresTableSource
         return lookupProvider;
     }
 
+    private void logFullCacheConfig() {
+        LookupOptions.ReloadStrategy reloadStrategy =
+                config.get(LookupOptions.FULL_CACHE_RELOAD_STRATEGY);
+        if (reloadStrategy.equals(LookupOptions.ReloadStrategy.PERIODIC)) {
+            LOG.debug(
+                    "Use Hologres FULL lookup cache for table {}, reloadStrategy={}, periodicInterval={}, scheduleMode={}.",
+                    tableName,
+                    reloadStrategy,
+                    config.get(LookupOptions.FULL_CACHE_PERIODIC_RELOAD_INTERVAL),
+                    config.get(LookupOptions.FULL_CACHE_PERIODIC_RELOAD_SCHEDULE_MODE));
+        } else {
+            LOG.debug(
+                    "Use Hologres FULL lookup cache for table {}, reloadStrategy={}, timedReloadTime={}, timedReloadIntervalInDays={}.",
+                    tableName,
+                    reloadStrategy,
+                    config.get(LookupOptions.FULL_CACHE_TIMED_RELOAD_ISO_TIME),
+                    config.get(LookupOptions.FULL_CACHE_TIMED_RELOAD_INTERVAL_IN_DAYS));
+        }
+    }
+
     private CacheReloadTrigger getCacheReloadTrigger() {
         if (config.get(LookupOptions.FULL_CACHE_RELOAD_STRATEGY)
                 .equals(LookupOptions.ReloadStrategy.PERIODIC)) {
@@ -174,13 +196,15 @@ public class HologresTableSource
 
     private ScanRuntimeProvider createScanRuntimeProvider() {
         String filterPredicate = String.join(" and ", resolvedPredicates);
-        HologresTableSchema hologresTableSchema =
-                HologresTableSchema.get(connectionParam.getJdbcOptions());
-        verifyBulkReadJob(tableSchema.getFieldNames(), hologresTableSchema);
         LOG.info("Filter predicate of bulk read is: " + filterPredicate);
         return InputFormatProvider.of(
                 new HologresBulkreadInputFormat(
-                        connectionParam, jdbcOptions, tableSchema, filterPredicate, limit));
+                        connectionParam,
+                        jdbcOptions,
+                        tableSchema,
+                        filterPredicate,
+                        limit,
+                        config.get(HologresConfigs.SCAN_SPLIT_COUNT)));
     }
 
     @Override
@@ -215,18 +239,5 @@ public class HologresTableSource
     @Override
     public void applyLimit(long limit) {
         this.limit = limit;
-    }
-
-    private void verifyBulkReadJob(String[] fieldNames, HologresTableSchema hologresTableSchema) {
-        for (String fieldName : fieldNames) {
-            Integer hologresColumnIndex = hologresTableSchema.get().getColumnIndex(fieldName);
-            if (hologresColumnIndex == null || hologresColumnIndex < 0) {
-                throw new IllegalArgumentException(
-                        "Hologres table "
-                                + hologresTableSchema.get().getTableName()
-                                + " does not have column "
-                                + fieldName);
-            }
-        }
     }
 }

--- a/hologres-connector-flink-base/src/main/java/com/alibaba/hologres/connector/flink/source/HologresTableSource.java
+++ b/hologres-connector-flink-base/src/main/java/com/alibaba/hologres/connector/flink/source/HologresTableSource.java
@@ -10,10 +10,15 @@ import org.apache.flink.table.connector.source.ScanTableSource;
 import org.apache.flink.table.connector.source.abilities.SupportsFilterPushDown;
 import org.apache.flink.table.connector.source.abilities.SupportsLimitPushDown;
 import org.apache.flink.table.connector.source.lookup.AsyncLookupFunctionProvider;
+import org.apache.flink.table.connector.source.lookup.FullCachingLookupProvider;
 import org.apache.flink.table.connector.source.lookup.LookupFunctionProvider;
+import org.apache.flink.table.connector.source.lookup.LookupOptions;
 import org.apache.flink.table.connector.source.lookup.PartialCachingAsyncLookupProvider;
 import org.apache.flink.table.connector.source.lookup.PartialCachingLookupProvider;
 import org.apache.flink.table.connector.source.lookup.cache.LookupCache;
+import org.apache.flink.table.connector.source.lookup.cache.trigger.CacheReloadTrigger;
+import org.apache.flink.table.connector.source.lookup.cache.trigger.PeriodicCacheReloadTrigger;
+import org.apache.flink.table.connector.source.lookup.cache.trigger.TimedCacheReloadTrigger;
 import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.util.Preconditions;
@@ -102,6 +107,10 @@ public class HologresTableSource
 
     @Override
     public LookupRuntimeProvider getLookupRuntimeProvider(LookupContext context) {
+        if (config.get(LookupOptions.CACHE_TYPE).equals(LookupOptions.LookupCacheType.FULL)) {
+            return FullCachingLookupProvider.of(createScanRuntimeProvider(), getCacheReloadTrigger());
+        }
+
         String[] lookupKeys = new String[context.getKeys().length];
         for (int i = 0; i < lookupKeys.length; i++) {
             int[] innerKeyArr = context.getKeys()[i];
@@ -149,8 +158,21 @@ public class HologresTableSource
         return lookupProvider;
     }
 
+    private CacheReloadTrigger getCacheReloadTrigger() {
+        if (config.get(LookupOptions.FULL_CACHE_RELOAD_STRATEGY)
+                .equals(LookupOptions.ReloadStrategy.PERIODIC)) {
+            return PeriodicCacheReloadTrigger.fromConfig(config);
+        } else {
+            return TimedCacheReloadTrigger.fromConfig(config);
+        }
+    }
+
     @Override
     public ScanRuntimeProvider getScanRuntimeProvider(ScanContext scanContext) {
+        return createScanRuntimeProvider();
+    }
+
+    private ScanRuntimeProvider createScanRuntimeProvider() {
         String filterPredicate = String.join(" and ", resolvedPredicates);
         HologresTableSchema hologresTableSchema =
                 HologresTableSchema.get(connectionParam.getJdbcOptions());

--- a/hologres-connector-flink-base/src/main/java/com/alibaba/hologres/connector/flink/source/bulkread/HologresBulkreadInputFormat.java
+++ b/hologres-connector-flink-base/src/main/java/com/alibaba/hologres/connector/flink/source/bulkread/HologresBulkreadInputFormat.java
@@ -37,6 +37,9 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /** Bulkread input format. */
 public class HologresBulkreadInputFormat extends RichInputFormat<RowData, HologresShardInputSplit>
@@ -48,33 +51,30 @@ public class HologresBulkreadInputFormat extends RichInputFormat<RowData, Hologr
     private final JDBCOptions options;
     private final String[] fieldNames;
     private final DataType[] fieldTypes;
-    private final String[] holoColumnTypes;
+    private transient String[] holoColumnTypes;
 
     private HologresBulkReader hologresBulkReader;
     private Tuple3<RowData, Integer, Long> record;
     private final String filterPredicate;
     private final long limit;
+    private final int scanSplitCount;
+    private long currentSplitStartMs;
+    private long currentSplitRecordCount;
 
     public HologresBulkreadInputFormat(
             HologresConnectionParam connectionParam,
             JDBCOptions jdbcOptions,
             TableSchema tableSchema,
             String filterPredicate,
-            long limit) {
+            long limit,
+            int scanSplitCount) {
         this.connectionParam = connectionParam;
         this.options = jdbcOptions;
         this.fieldNames = tableSchema.getFieldNames();
         this.fieldTypes = tableSchema.getFieldDataTypes();
-        this.holoColumnTypes = new String[fieldNames.length];
-        HologresTableSchema hologresTableSchema =
-                HologresTableSchema.get(connectionParam.getJdbcOptions());
-        for (int i = 0; i < fieldNames.length; i++) {
-            Integer hologresColumnIndex = hologresTableSchema.get().getColumnIndex(fieldNames[i]);
-            this.holoColumnTypes[i] =
-                    hologresTableSchema.get().getColumn(hologresColumnIndex).getTypeName();
-        }
         this.filterPredicate = filterPredicate;
         this.limit = limit;
+        this.scanSplitCount = scanSplitCount;
     }
 
     @Override
@@ -83,15 +83,14 @@ public class HologresBulkreadInputFormat extends RichInputFormat<RowData, Hologr
 
         LOG.info("Creating input splits for Holo shards");
 
-        int numShards = JDBCUtils.getShardCount(options);
+        int shardCount = JDBCUtils.getShardCount(options);
+        HologresShardInputSplit[] splits = createShardInputSplits(shardCount, scanSplitCount);
 
-        HologresShardInputSplit[] splits = new HologresShardInputSplit[numShards];
-
-        for (int i = 0; i < numShards; i++) {
-            splits[i] = new HologresShardInputSplit(i);
-        }
-
-        LOG.info("Created {} input splits for Holo shards", splits.length);
+        LOG.info(
+                "Created {} input splits for {} Holo shards, configured split count {}",
+                splits.length,
+                shardCount,
+                scanSplitCount);
 
         return splits;
     }
@@ -104,7 +103,13 @@ public class HologresBulkreadInputFormat extends RichInputFormat<RowData, Hologr
 
     @Override
     public void open(HologresShardInputSplit inputSplit) throws IOException {
-        LOG.info("Opening HoloShardInputSplit {}", inputSplit.getSplitNumber());
+        LOG.info(
+                "Opening HoloShardInputSplit {}, shard ids {}",
+                inputSplit.getSplitNumber(),
+                Arrays.toString(inputSplit.getShardIds()));
+        currentSplitStartMs = System.currentTimeMillis();
+        currentSplitRecordCount = 0;
+        initializeHoloColumnTypes();
         hologresBulkReader =
                 new HologresBulkReader(
                         connectionParam,
@@ -112,11 +117,49 @@ public class HologresBulkreadInputFormat extends RichInputFormat<RowData, Hologr
                         fieldNames,
                         fieldTypes,
                         holoColumnTypes,
-                        new String[] {String.valueOf(inputSplit.getSplitNumber())},
+                        inputSplit.getShardIds(),
                         false,
                         filterPredicate,
                         limit);
         hologresBulkReader.open();
+    }
+
+    static HologresShardInputSplit[] createShardInputSplits(
+            int shardCount, int configuredSplitCount) {
+        int splitCount =
+                configuredSplitCount > 0 ? Math.min(configuredSplitCount, shardCount) : shardCount;
+        List<HologresShardInputSplit> splits = new ArrayList<>(splitCount);
+        for (int splitNumber = 0; splitNumber < splitCount; splitNumber++) {
+            int startInclusive = splitNumber * shardCount / splitCount;
+            int endExclusive = (splitNumber + 1) * shardCount / splitCount;
+            String[] shardIds = new String[endExclusive - startInclusive];
+            for (int shardId = startInclusive; shardId < endExclusive; shardId++) {
+                shardIds[shardId - startInclusive] = String.valueOf(shardId);
+            }
+            splits.add(new HologresShardInputSplit(splitNumber, shardIds));
+        }
+        return splits.toArray(new HologresShardInputSplit[0]);
+    }
+
+    private void initializeHoloColumnTypes() {
+        if (holoColumnTypes != null) {
+            return;
+        }
+        HologresTableSchema hologresTableSchema =
+                HologresTableSchema.get(connectionParam.getJdbcOptions());
+        holoColumnTypes = new String[fieldNames.length];
+        for (int i = 0; i < fieldNames.length; i++) {
+            Integer hologresColumnIndex = hologresTableSchema.get().getColumnIndex(fieldNames[i]);
+            if (hologresColumnIndex == null || hologresColumnIndex < 0) {
+                throw new IllegalArgumentException(
+                        "Hologres table "
+                                + hologresTableSchema.get().getTableName()
+                                + " does not have column "
+                                + fieldNames[i]);
+            }
+            holoColumnTypes[i] =
+                    hologresTableSchema.get().getColumn(hologresColumnIndex).getTypeName();
+        }
     }
 
     @Override
@@ -126,6 +169,7 @@ public class HologresBulkreadInputFormat extends RichInputFormat<RowData, Hologr
 
     @Override
     public RowData nextRecord(RowData reuse) throws IOException {
+        currentSplitRecordCount++;
         return record.f0;
     }
 
@@ -134,6 +178,10 @@ public class HologresBulkreadInputFormat extends RichInputFormat<RowData, Hologr
         if (hologresBulkReader != null) {
             hologresBulkReader.close();
         }
+        LOG.info(
+                "Closed HoloShardInputSplit, loaded {} records, cost {} ms",
+                currentSplitRecordCount,
+                System.currentTimeMillis() - currentSplitStartMs);
     }
 
     @Override

--- a/hologres-connector-flink-base/src/main/java/com/alibaba/hologres/connector/flink/source/bulkread/HologresShardInputSplit.java
+++ b/hologres-connector-flink-base/src/main/java/com/alibaba/hologres/connector/flink/source/bulkread/HologresShardInputSplit.java
@@ -20,17 +20,23 @@ package com.alibaba.hologres.connector.flink.source.bulkread;
 
 import org.apache.flink.core.io.InputSplit;
 
-/** An input split that represents a Holo shard, where split number equals shard id. */
+/** An input split that represents one or more Holo shards. */
 public class HologresShardInputSplit implements InputSplit {
 
-    private final int shardId; // shard id == split number
+    private final int splitNumber;
+    private final String[] shardIds;
 
-    public HologresShardInputSplit(int splitNumber) {
-        this.shardId = splitNumber;
+    public HologresShardInputSplit(int splitNumber, String[] shardIds) {
+        this.splitNumber = splitNumber;
+        this.shardIds = shardIds;
     }
 
     @Override
     public int getSplitNumber() {
-        return shardId;
+        return splitNumber;
+    }
+
+    public String[] getShardIds() {
+        return shardIds;
     }
 }

--- a/hologres-connector-flink-base/src/test/java/com/alibaba/hologres/connector/flink/source/bulkread/HologresBulkreadInputFormatTest.java
+++ b/hologres-connector-flink-base/src/test/java/com/alibaba/hologres/connector/flink/source/bulkread/HologresBulkreadInputFormatTest.java
@@ -1,0 +1,50 @@
+package com.alibaba.hologres.connector.flink.source.bulkread;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for Hologres bulk read split planning. */
+public class HologresBulkreadInputFormatTest {
+
+    @Test
+    public void testDefaultSplitCountKeepsOneSplitPerShard() {
+        HologresShardInputSplit[] splits =
+                HologresBulkreadInputFormat.createShardInputSplits(32, -1);
+
+        Assert.assertEquals(32, splits.length);
+        Assert.assertArrayEquals(new String[] {"0"}, splits[0].getShardIds());
+        Assert.assertArrayEquals(new String[] {"31"}, splits[31].getShardIds());
+    }
+
+    @Test
+    public void testConfiguredSplitCountMergesShards() {
+        HologresShardInputSplit[] splits =
+                HologresBulkreadInputFormat.createShardInputSplits(32, 4);
+
+        Assert.assertEquals(4, splits.length);
+        Assert.assertArrayEquals(
+                new String[] {"0", "1", "2", "3", "4", "5", "6", "7"}, splits[0].getShardIds());
+        Assert.assertArrayEquals(
+                new String[] {"24", "25", "26", "27", "28", "29", "30", "31"},
+                splits[3].getShardIds());
+    }
+
+    @Test
+    public void testSplitCountLargerThanShardCountKeepsOneSplitPerShard() {
+        HologresShardInputSplit[] splits =
+                HologresBulkreadInputFormat.createShardInputSplits(3, 10);
+
+        Assert.assertEquals(3, splits.length);
+        Assert.assertArrayEquals(new String[] {"0"}, splits[0].getShardIds());
+        Assert.assertArrayEquals(new String[] {"1"}, splits[1].getShardIds());
+        Assert.assertArrayEquals(new String[] {"2"}, splits[2].getShardIds());
+    }
+
+    @Test
+    public void testSingleSplitCanReadAllShards() {
+        HologresShardInputSplit[] splits = HologresBulkreadInputFormat.createShardInputSplits(4, 1);
+
+        Assert.assertEquals(1, splits.length);
+        Assert.assertArrayEquals(new String[] {"0", "1", "2", "3"}, splits[0].getShardIds());
+    }
+}


### PR DESCRIPTION
## Summary

Support Flink standard FULL lookup cache for the Hologres Flink connector.

When `lookup.cache = 'FULL'`, the connector now returns Flink's `FullCachingLookupProvider`, so lookup joins can load dimension data into local cache and refresh it by Flink full-cache reload options.

## Changes

- Support `lookup.cache = 'FULL'` for Hologres lookup table.
- Support Flink full-cache reload trigger options, including periodic reload.
- Add `source.scan.split-count` to control Hologres full-scan split count.
- Allow multiple Hologres shards to be read by one input split, reducing connection count during full-cache loading.
- Avoid unnecessary Hologres connections during planning/explain by lazily initializing scan metadata.
- Add unit tests for full-cache lookup and shard split generation.

## Verification

- `mvn -pl hologres-connector-flink-base,hologres-connector-flink-1.19 -am validate`
- `mvn -pl hologres-connector-flink-base -Dtest=HologresBulkreadInputFormatTest test`
