### PR TITLE
Spark catalog: add defaultDatabase config and override defaultNamespace

### DIFF
--- a/hologres-connector-spark-3.x/src/main/scala/com/alibaba/hologres/spark3/HoloTableCatalog.scala
+++ b/hologres-connector-spark-3.x/src/main/scala/com/alibaba/hologres/spark3/HoloTableCatalog.scala
@@ -29,12 +29,17 @@ class HoloTableCatalog extends TableCatalog with SupportsNamespaces with Logging
   override def initialize(name: String, options: CaseInsensitiveStringMap): Unit = {
     assert(catalogName == null, "The Holo table catalog is already initialed")
     catalogName = name
+    currentHoloSchema = options.getOrDefault(SourceProvider.DEFAULT_DATABASE, currentHoloSchema)
     hologresConfigs = new HologresConfigs(options.asScala.toMap)
   }
 
   override def name(): String = {
     require(catalogName != null, "The Holo table catalog is not initialed")
     catalogName
+  }
+
+  override def defaultNamespace(): Array[String] = {
+    Array(currentHoloSchema)
   }
 
   override def listTables(namespace: Array[String]): Array[Identifier] = {

--- a/hologres-connector-spark-base/src/main/scala/com/alibaba/hologres/spark/BaseSourceProvider.scala
+++ b/hologres-connector-spark-base/src/main/scala/com/alibaba/hologres/spark/BaseSourceProvider.scala
@@ -4,6 +4,7 @@ import scala.reflect.runtime.{universe => ru}
 
 class BaseSourceProvider() {
   val DATABASE = "database"
+  val DEFAULT_DATABASE = "defaultdatabase"
   val TABLE = "table"
   val USERNAME = "username"
   val PASSWORD = "password"


### PR DESCRIPTION
Add `defaultdatabase` config to `HoloTableCatalog` for setting the default Hologres schema (defaults to `public`), and override `defaultNamespace()` to use it instead of Spark's hardcoded `"default"` which does not exist in Hologres.