### PR TITLE
Fix stage write resource leak on speculative execution kill

### DIFF
--- a/holo-client/src/main/java/com/alibaba/hologres/client/copy/in/CopyInStageWrapper.java
+++ b/holo-client/src/main/java/com/alibaba/hologres/client/copy/in/CopyInStageWrapper.java
@@ -39,6 +39,8 @@ public class CopyInStageWrapper<RECORD> implements AutoCloseable {
 
     private RateLimiter rateLimiter;
 
+    private volatile boolean closed = false;
+
     public CopyInStageWrapper(
             HoloConfig config,
             String stageName,
@@ -128,13 +130,39 @@ public class CopyInStageWrapper<RECORD> implements AutoCloseable {
         copyInStageFromBytes(data);
     }
 
+    public void abort() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        LOGGER.info("CopyInStageWrapper abort begin");
+        try {
+            arrowWriter.close();
+        } finally {
+            if (connectionHolder != null) {
+                connectionHolder.close();
+            }
+        }
+        LOGGER.info("CopyInStageWrapper abort end");
+    }
+
     @Override
     public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
         LOGGER.info("CopyInStageWrapper close begin");
         try {
             flush();
         } finally {
-            arrowWriter.close();
+            try {
+                arrowWriter.close();
+            } finally {
+                if (connectionHolder != null) {
+                    connectionHolder.close();
+                }
+            }
         }
         LOGGER.info("CopyInStageWrapper close end");
     }

--- a/hologres-connector-spark-3.x/src/main/scala/com/alibaba/hologres/spark3/sink/HoloWriterBuilder.scala
+++ b/hologres-connector-spark-3.x/src/main/scala/com/alibaba/hologres/spark3/sink/HoloWriterBuilder.scala
@@ -88,7 +88,7 @@ class HoloBatchWriter(
 
   override def abort(messages: Array[WriterCommitMessage]): Unit = {
     logger.warn("HoloBatchWriter abort: " + LocalDateTime.now())
-    if ("stage" == hologresConfigs.writeMode && messages != null) {
+    if ("stage" == hologresConfigs.writeMode && !hologresConfigs.copyStageOnly && messages != null) {
       val stageNames = messages.filter(_ != null).collect {
         case m: StageWriterCommitMessage => m.stageName
       }

--- a/hologres-connector-spark-3.x/src/main/scala/com/alibaba/hologres/spark3/sink/HoloWriterBuilder.scala
+++ b/hologres-connector-spark-3.x/src/main/scala/com/alibaba/hologres/spark3/sink/HoloWriterBuilder.scala
@@ -88,6 +88,19 @@ class HoloBatchWriter(
 
   override def abort(messages: Array[WriterCommitMessage]): Unit = {
     logger.warn("HoloBatchWriter abort: " + LocalDateTime.now())
+    if ("stage" == hologresConfigs.writeMode && messages != null) {
+      val stageNames = messages.filter(_ != null).collect {
+        case m: StageWriterCommitMessage => m.stageName
+      }
+      if (stageNames.nonEmpty) {
+        try {
+          JDBCUtil.dropStages(hologresConfigs, stageNames)
+        } catch {
+          case e: Exception =>
+            logger.warn("Failed to drop stages on batch abort", e)
+        }
+      }
+    }
     if (is_overwrite) {
       JDBCUtil.deleteTempTableForOverWrite(hologresConfigs)
     }

--- a/hologres-connector-spark-base/src/main/scala/com/alibaba/hologres/spark/sink/copy/BaseHoloDataCopyStageWriter.scala
+++ b/hologres-connector-spark-base/src/main/scala/com/alibaba/hologres/spark/sink/copy/BaseHoloDataCopyStageWriter.scala
@@ -6,7 +6,7 @@ import com.alibaba.hologres.client.model.TableSchema
 import com.alibaba.hologres.client.utils.RateLimiter
 import com.alibaba.hologres.spark.config.HologresConfigs
 import com.alibaba.hologres.spark.sink._
-import com.alibaba.hologres.spark.utils.LoggerWrapper
+import com.alibaba.hologres.spark.utils.{JDBCUtil, LoggerWrapper}
 import org.apache.spark.internal.Logging
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.connector.write.WriterCommitMessage
@@ -69,14 +69,31 @@ abstract class BaseHoloDataCopyStageWriter(hologresConfigs: HologresConfigs,
   }
 
   def abort(): Unit = {
-    logger.debug("Abort....")
-    close()
+    logger.info("Abort, dropping stage: " + stageName)
+    try {
+      if (stageWrapper != null) {
+        stageWrapper.abort()
+      }
+    } catch {
+      case e: Exception =>
+        logger.warn("Error aborting stageWrapper", e)
+    }
+    try {
+      JDBCUtil.dropStages(hologresConfigs, Array(stageName))
+    } catch {
+      case e: Exception =>
+        logger.warn("Failed to drop stage on abort: " + stageName, e)
+    }
   }
 
   protected def close(): Unit = {
     if (stageWrapper != null) {
-      stageWrapper.flush()
-      stageWrapper.close()
+      try {
+        stageWrapper.close()
+      } catch {
+        case e: Exception =>
+          logger.warn("Error closing stageWrapper", e)
+      }
     }
     logger.debug("Close....")
   }


### PR DESCRIPTION
## Summary

- Stage write `abort()` no longer flushes the broken Arrow channel, avoiding `ClosedChannelException` cascades
- `abort()` actively drops the orphaned stage instead of relying on 7200s TTL expiration
- Fix `CopyInStageWrapper` `connectionHolder` leak (never closed in any code path before)
- `HoloBatchWriter.abort()` now cleans up stages on job-level failure

## Background

When speculative execution kills a stage write task, the current `abort()` attempts to flush an already-interrupted Arrow channel, causing cascading exceptions. The created stage is never dropped, and the connectionHolder is never closed.

**Executor log (sanitized):**

```
16:40:40 INFO  Executor - Got assigned task 64411
16:40:40 INFO  Executor - Running task 21.1 in stage 166.0 (TID 64411)
16:40:40 INFO  JDBCUtil - create connection to holo
16:40:40 INFO  JDBCUtil - execute sql success: call hologres.hg_create_internal_stage(...)
16:40:40 INFO  Executor - Executor is trying to kill task 21.1 in stage 166.0 (TID 64411), reason: another attempt succeeded
16:40:40 ERROR Utils - Aborting task
java.nio.channels.ClosedByInterruptException
    at AbstractInterruptibleChannel.end(...)
    at ArrowWriter.writeBatch(...)
    at CopyInStageWrapper.putRecord(...)
    at BaseHoloDataCopyStageWriter.write(...)
16:40:40 ERROR DataWritingSparkTask - Aborting commit for partition 21 (task 64411, attempt 1, stage 166.0)
16:40:40 WARN  Utils - Suppressing exception in catch:
java.nio.channels.ClosedChannelException    ← abort() flush triggers again
    at CopyInStageWrapper.flush(...)
    at BaseHoloDataCopyStageWriter.close(...)
    at BaseHoloDataCopyStageWriter.abort(...)
16:40:41 WARN  Utils - Suppressing exception in finally:
java.nio.channels.ClosedChannelException    ← close() triggers again
    at CopyInStageWrapper.flush(...)
    at BaseHoloDataCopyStageWriter.close(...)
16:40:41 INFO  Executor - Executor interrupted and killed task 21.1, reason: another attempt succeeded
```

**After fix:**
```
abort() → stageWrapper.abort() (no flush, close resources) → dropStages (cleanup)
close() → stageWrapper already closed, return immediately (idempotent)
```

## Test plan

- [ ] Compile: `mvn compile -pl hologres-connector-spark-3.x -am -DskipTests`
- [ ] Enable `spark.speculation=true`, run a skewed write-to-Hologres job
- [ ] Verify no `ClosedChannelException` cascades in executor logs
- [ ] Verify stage cleanup: `SELECT * FROM hologres.hg_internal_stage_info` shows no orphaned stages

🤖 Generated with [Claude Code](https://claude.com/claude-code)